### PR TITLE
ci(workflows): add concurrency to win-install + deploy-gh-pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     if: github.repository == 'z-shell/src'

--- a/.github/workflows/win-install.yml
+++ b/.github/workflows/win-install.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ZSH-1 CI modernization (perms/concurrency sweep). Both workflows had `permissions` but no `concurrency` block. Adds standard concurrency groups; `deploy-gh-pages` uses `cancel-in-progress: false` so deploys aren't interrupted mid-run.